### PR TITLE
add more coarse filter for organ type on the explore page

### DIFF
--- a/packages/data-portal-commons/src/lib/getCaseValues.ts
+++ b/packages/data-portal-commons/src/lib/getCaseValues.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { Entity } from './entity';
+import { getNormalizedOrgan } from '@htan/data-portal-commons';
 
 export function getCaseValues(propName: keyof Entity) {
     return (e: Entity) => {
@@ -7,6 +8,16 @@ export function getCaseValues(propName: keyof Entity) {
             return _.uniq(e.cases.map((c) => c[propName] as string));
         } else {
             return [e[propName] as string];
+        }
+    };
+}
+
+export function getNormalizedOrganCaseValues() {
+    return (e: Entity) => {
+        if (e.cases) {
+            return _.uniq(e.cases.map((c) => getNormalizedOrgan(c) as string));
+        } else {
+            return [getNormalizedOrgan(e) as string];
         }
     };
 }

--- a/packages/data-portal-commons/src/lib/types.ts
+++ b/packages/data-portal-commons/src/lib/types.ts
@@ -3,7 +3,7 @@ import {
     GenericAttributeNames,
     IAttributeInfo,
 } from '@htan/data-portal-utils';
-import { getCaseValues } from './getCaseValues';
+import { getCaseValues, getNormalizedOrganCaseValues } from './getCaseValues';
 import { Atlas, Entity, SerializableEntity } from './entity';
 
 export enum HTANAttributeNames {
@@ -31,9 +31,14 @@ export const HTANToGenericAttributeMap: {
 export const FileAttributeMap: {
     [attr in AttributeNames]: IAttributeInfo<Entity>;
 } = {
+    [AttributeNames.OrganType]: {
+        getValues: getNormalizedOrganCaseValues(),
+        displayName: 'Organ',
+        caseFilter: true,
+    },
     [AttributeNames.TissueorOrganofOrigin]: {
         getValues: getCaseValues('TissueorOrganofOrigin'),
-        displayName: 'Organ',
+        displayName: 'Organ Details',
         caseFilter: true,
     },
     [AttributeNames.PrimaryDiagnosis]: {

--- a/packages/data-portal-explore/src/components/FileFilterControls.tsx
+++ b/packages/data-portal-explore/src/components/FileFilterControls.tsx
@@ -55,7 +55,11 @@ export const FileFilterControls: React.FunctionComponent<IFileFilterControlProps
                 />
                 <FilterDropdown
                     {...dropdownProps}
-                    attributes={[AttributeNames.TissueorOrganofOrigin]}
+                    attributes={[
+                        AttributeNames.OrganType,
+                        AttributeNames.TissueorOrganofOrigin,
+                    ]}
+                    className={styles.filterCheckboxListContainer}
                 />
                 <FilterDropdown
                     {...dropdownProps}

--- a/packages/data-portal-utils/src/lib/types.ts
+++ b/packages/data-portal-utils/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface IAttributeInfo<T> {
 
 export enum AttributeNames {
     // Synapse attribute names
+    OrganType = 'OrganType',
     TissueorOrganofOrigin = 'TissueorOrganofOrigin',
     PrimaryDiagnosis = 'PrimaryDiagnosis',
     Gender = 'Gender',


### PR DESCRIPTION
Fixing the #595 issue:
1. Created a filter by Organ Type filter on the organ dropdown box on the explore page.
2. Changed the original 'Organ' label in the dropdown box to the 'Organ Details'.